### PR TITLE
Update setup.py according to PEP 508 URLs dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,6 @@
 import os
 import subprocess
 
-#TRACER_URL = 'git+ssh://git@git.seclab.cs.ucsb.edu:/cgc/tracer.git#egg=tracer'
-#ANGROP_URL = 'git+ssh://git@git.seclab.cs.ucsb.edu:/angr/angrop.git#egg=angrop'
-#
-## this is really gross, but you do what you gotta do
-#if subprocess.call(['pip', 'install', TRACER_URL]) != 0:
-#   raise LibError("Unable to install tracer")
-#
-#if subprocess.call(['pip', 'install', ANGROP_URL]) != 0:
-#   raise LibError("Unable to install angrop")
-
 try:
     from setuptools import setup
     from setuptools import find_packages
@@ -20,21 +10,15 @@ except ImportError:
     packages = [x.strip('./').replace('/', '.') for x in os.popen('find -name "__init__.py" | xargs -n1 dirname').read().strip().split('\n')]
 
 setup(
-      name='rex',
-      version='0.02',
-      packages=packages,
-      install_requires=[
-            'angr',
-            'povsim',
-            'tracer',
-            'angrop',
-            'compilerex',
-            'archr',
-      ],
-      dependency_links=[
-          'git+ssh://git@github.com/mechaphish/compilerex#egg=compilerex',
-          'git+ssh://git@github.com/mechaphish/povsim#egg=povsim',
-          'git+ssh://git@github.com/angr/archr#egg=archr',
-          'git+ssh://git@github.com/angr/tracer#egg=tracer',
-      ],
+    name='rex',
+    version='0.02',
+    packages=packages,
+    install_requires=[
+        'angr',
+        'archr',
+        'angrop',
+        'tracer @ git://github.com/angr/tracer',
+        'povsim @ git://github.com/mechaphish/povsim',
+        'compilerex @ git://github.com/mechaphish/compilerex',
+    ],
 )


### PR DESCRIPTION
The current setup.py does not work with pip>=19.0.
See https://github.com/pypa/pip/issues/4187#issuecomment-415667805.

If rex ever makes its way to pypi, this setup.py will not work due to the remote url dependencies.