### PR TITLE
Fix VCS URLs for dependencies tracer, povsim and compilerex

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,8 @@ setup(
         'angr',
         'archr',
         'angrop',
-        'tracer @ git://github.com/angr/tracer',
-        'povsim @ git://github.com/mechaphish/povsim',
-        'compilerex @ git://github.com/mechaphish/compilerex',
+        'tracer @ git+https://github.com/angr/tracer',
+        'povsim @ git+https://github.com/mechaphish/povsim',
+        'compilerex @ git+https://github.com/mechaphish/compilerex',
     ],
 )


### PR DESCRIPTION
The URLs for `tracer`, `povsim` and `compilerex` are not proper VCS URLs supported by pip and so `pip install -e` failed. This commit fixes the VCS URLs for those dependencies to enable pip installing rex.